### PR TITLE
Add pix2ang functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,8 +113,21 @@ export function pix2vec_nest(nside: number, ipix: number) {
 }
 
 
+export function pix2ang_nest(nside: number, ipix: number) {
+    const { f, x, y } = nest2fxy(nside, ipix)
+    const { t, u } = fxy2tu(nside, f, x, y)
+    const { z, a } = tu2za(t, u)
+    return { theta: Math.acos(z), phi: a }
+}
+
+
 export function pix2vec_ring(nside: number, ipix: number) {
     return pix2vec_nest(nside, ring2nest(nside, ipix))
+}
+
+
+export function pix2ang_ring(nside: number, ipix: number) {
+    return pix2ang_nest(nside, ring2nest(nside, ipix))
 }
 
 


### PR DESCRIPTION
@michitaro - How do you feel about adding `pix2ang` functions?

In my experience `ang` is commonly used, not just `vec`.

This is the equivalent of http://healpy.readthedocs.io/en/latest/generated/healpy.pixelfunc.pix2ang.html

If you want to include it, I could try to add a test.