### PR TITLE
Rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install --save @hscmap/healpix
 
 Then from your Javascript (JS) or Typescript (TS) file, import and use `healpix` like this:
 ```js
-import { healpix } from 'healpix';
+import * as healpix from 'healpix';
 
 console.log(healpix.order2nside(0));
 ```

--- a/README.md
+++ b/README.md
@@ -2,66 +2,92 @@
 
 ## Introduction
 
-* This module is an implementation of [HEALPix](http://healpix.sourceforge.net) in JavaScript / TypeScript.
-* Pixelisation-related functions (including corners) and disk query are available
-  for the ring and nested HEALPix pixelisation schemes.
-* Most API interfaces are ported from wonderful [healpy](https://healpy.readthedocs.io/en/latest/)
-* See [API documentation](https://michitaro.github.io/healpix/typedoc/modules/_index_.html) and [Working demo](http://michitaro.github.io/healpix/)
+This module is an implementation of [HEALPix](http://healpix.sourceforge.net) in [TypeScript](https://www.typescriptlang.org/). A Javascript version is available as well. (Typescript is a typed superset of Javascript, that compiles to Javascript.)
 
-## Install
+This package was implemented based on the description in the [HEALPix paper](http://iopscience.iop.org/article/10.1086/427976/pdf). Pixelisation-related functions (including corners) and disk query are available for the ring and nested HEALPix pixelisation schemes. Most API interfaces are ported from wonderful [healpy](https://healpy.readthedocs.io/) Python package, and tests against `healpy` are used to show correctness.
+
+The following sections explain installation and usage, and give examples. Detailed [API documentation](https://michitaro.github.io/healpix/typedoc/modules/_index_.html) is also available.
+
+## Installation and Usage
+
+### With NPM
+
+If you are using [Node.js](https://nodejs.org/), you can download and install [@hscmap/healpix](https://www.npmjs.com/package/@hscmap/healpix) with [npm](https://www.npmjs.com/):
+
 ```sh
-npm install @hscmap/healpix
+npm install --save @hscmap/healpix
 ```
 
-## Example (code of [the working demo #1](http://michitaro.github.io/healpix/pixcoord2vec))
+Then from your Javascript (JS) or Typescript (TS) file, import and use `healpix` like this:
+```js
+import { healpix } from 'healpix';
 
-![Screenshot](./docs/images/pixcoord2vec.png)
-
-```typescript
-import * as healpix from '@hscmap/healpix'
-import { PerspectiveCanvas } from "./perspective_canvas"
-
-
-function draw(canvas: PerspectiveCanvas, theta: number, phi: number) {
-    const nstep = 8
-    const nside = 4
-    const npix = 12 * nside * nside
-
-    canvas.phi = phi
-    canvas.theta = theta
-    canvas.clear()
-
-    for (let ipix = 0; ipix < npix; ++ipix) {
-        canvas.path(lineTo => {
-            for (let i = 0; i < nstep; ++i) {
-                const ne = i / nstep
-                const v = healpix.pixcoord2vec_nest(nside, ipix, ne, 0)
-                lineTo(v)
-            }
-            for (let i = 0; i <= nstep; ++i) {
-                const nw = i / nstep
-                const v = healpix.pixcoord2vec_nest(nside, ipix, 1, nw)
-                lineTo(v)
-            }
-        })
-    }
-}
-
-
-window.addEventListener('load', e => {
-    const canvas = new PerspectiveCanvas(document.getElementById('main') as HTMLCanvasElement)
-    draw(canvas, 0, 0)
-    window.addEventListener('mousemove', e => {
-        const theta = Math.PI * e.clientY / window.innerHeight
-        const phi = Math.PI * e.clientX / window.innerHeight
-        draw(canvas, theta, phi)
-    })
-})
+console.log(healpix.order2nside(0));
 ```
+
+### Standalone JS
+
+Another option is to use ``healpix.js`` as a standalone library.
+
+Thanks to the [unpkg](https://unpkg.com/) CDN, you can simply add this line to your HTML file:
+```html
+<script src="https://unpkg.com/@hscmap/healpix@latest/standalone/dist/healpix.js"></script>
+```
+and after that line you can call `healpix` functions like this:
+```html
+<script>
+console.log(healpix.order2nside(0));
+</script>
+```
+If you don't want to use the latest version, select one from [here](https://unpkg.com/@hscmap/healpix).
+
+## Examples
+
+Examples using `healpix` are available here: http://michitaro.github.io/healpix/
+
+The code is available here:
+
+* [docs/example/src/pixcoord2vec](docs/example/src/pixcoord2vec)
+* [docs/example/src/query_disc](docs/example/src/query_disc)
+
+Instructions how to build the examples locally are in the next section.
+
+## Developer documentation
+
+To hack on this package, clone https://github.com/michitaro/healpix from Github:
+```
+git clone https://github.com/michitaro/healpix.git
+cd healpix
+```
+
+Then run `npm install` to install the tools and dependencies used (especially [Typescript](https://www.typescriptlang.org/) and [Webpack](https://webpack.js.org/)):
+```sh
+npm install
+```
+
+The package is implemented in a single Typescript file: [src/index.ts](src/index.ts).
+
+To generate the standalone Javascript package ``standalone/dist/healpix.js``, run this command:
+```sh
+npm run standalone
+```
+
+To compile and run the examples locally:
+```
+npm run build-example
+```
+
+To test the package install Python and [healpy](http://healpy.readthedocs.io/) first, and then run:
+```
+npm run my-test
+```
+
+Feedback, issues and contributions welcome: https://github.com/michitaro/healpix
 
 ## See Also
 * http://healpix.sourceforge.net
 * https://healpy.readthedocs.io
 
-# License
+## License
+
 This software is released under the MIT License, see LICENSE.


### PR DESCRIPTION
@michitaro - This is an attempt to improve the README, following  #6.

- Extend the intro a bit
- Extend the install / use
- Add developer doc section
- Remove the long JS example using canvas from the front page, just link to the example.

It's written more from the perspective of people new TS / JS, like me, focused on step by step commands to get started.

Specifically for the "isntall and use with npm" section I'm not sure if the description is accurate. Is it the same for TS / JS projects? Is this line correct (I didn't try yet)? 
```
import { healpix } from 'healpix';
```
Or is this `*` import like in your examples needed? I'm just familiar with Python, where `*` imports are discouraged.