### PR TITLE
Add ring2fxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -373,7 +373,7 @@ function tu2fxy(nside: number, t: number, u: number) {
     const { f, p, q } = tu2fpq(t, u)
     const x = clamp(Math.floor(nside * p), 0, nside - 1)
     const y = clamp(Math.floor(nside * q), 0, nside - 1)
-    return { x, f, y }
+    return { f, x, y }
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,11 +58,15 @@ export function nest2ring(nside: number, ipix: number) {
     return fxy2ring(nside, f, x, y)
 }
 
-
-// TODO: cleanup
 export function ring2nest(nside: number, ipix: number) {
-    if (nside == 1)
-        return ipix
+    if (nside == 1) {
+        return ipix;
+    }
+    const { f, x, y } = ring2fxy(nside, ipix)
+    return fxy2nest(nside, f, x, y)
+}
+
+export function ring2fxy(nside: number, ipix: number) {
     const polar_lim = 2 * nside * (nside - 1)
     if (ipix < polar_lim) { // north polar cap
         const i = Math.floor((Math.sqrt(1 + 2 * ipix) + 1) / 2)
@@ -71,7 +75,7 @@ export function ring2nest(nside: number, ipix: number) {
         const k = j % i
         const x = nside - i + k
         const y = nside - 1 - k
-        return fxy2nest(nside, f, x, y)
+        return {f, x, y}
     }
     if (ipix < polar_lim + 8 * nside * nside) { // equatorial belt
         const k = ipix - polar_lim
@@ -90,7 +94,7 @@ export function ring2nest(nside: number, ipix: number) {
         const f = 4 * V + (H >> 1) % 4
         const x = pp % nside
         const y = qq % nside
-        return fxy2nest(nside, f, x, y)
+        return {f, x, y}
     }
     else { // south polar cap
         const p = 12 * nside * nside - ipix - 1
@@ -100,7 +104,7 @@ export function ring2nest(nside: number, ipix: number) {
         const k = j % i
         const x = i - k - 1
         const y = k
-        return fxy2nest(nside, f, x, y)
+        return {f, x, y}
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export function nest2ring(nside: number, ipix: number) {
 
 export function ring2nest(nside: number, ipix: number) {
     if (nside == 1) {
-        return ipix;
+        return ipix
     }
     const { f, x, y } = ring2fxy(nside, ipix)
     return fxy2nest(nside, f, x, y)

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export function ring2nest(nside: number, ipix: number) {
     return fxy2nest(nside, f, x, y)
 }
 
-export function ring2fxy(nside: number, ipix: number) {
+function ring2fxy(nside: number, ipix: number) {
     const polar_lim = 2 * nside * (nside - 1)
     if (ipix < polar_lim) { // north polar cap
         const i = Math.floor((Math.sqrt(1 + 2 * ipix) + 1) / 2)
@@ -75,7 +75,7 @@ export function ring2fxy(nside: number, ipix: number) {
         const k = j % i
         const x = nside - i + k
         const y = nside - 1 - k
-        return {f, x, y}
+        return { f, x, y }
     }
     if (ipix < polar_lim + 8 * nside * nside) { // equatorial belt
         const k = ipix - polar_lim
@@ -94,7 +94,7 @@ export function ring2fxy(nside: number, ipix: number) {
         const f = 4 * V + (H >> 1) % 4
         const x = pp % nside
         const y = qq % nside
-        return {f, x, y}
+        return { f, x, y }
     }
     else { // south polar cap
         const p = 12 * nside * nside - ipix - 1
@@ -104,7 +104,7 @@ export function ring2fxy(nside: number, ipix: number) {
         const k = j % i
         const x = i - k - 1
         const y = k
-        return {f, x, y}
+        return { f, x, y }
     }
 }
 


### PR DESCRIPTION
This PR adds `ring2fxy` and calls it from `ring2nest`. I think that's easier to understand, making it clear that his package always goes via `fxy`.

There is a second commit, changing the return in `tu2fxy` to order `fxy` like in all other functions. Apparently there was no caller relying on this, at least no test is failing.

Overall I wonder if we should create `V3` and `FXY` objects when returning things?
Note how [vec2ang](https://michitaro.github.io/healpix/typedoc/modules/_index_.html#vec2ang) shows a `V3` object going in, but [ang2vec](https://michitaro.github.io/healpix/typedoc/modules/_index_.html#ang2vec) doesn't show one coming out, just "Object".
@michitaro - Do you think we should make a change here, or keep as is e.g. for performance reasons?