### PR TITLE
Rename clamp to clip

### DIFF
--- a/docs/example/src/query_disc/main.ts
+++ b/docs/example/src/query_disc/main.ts
@@ -61,12 +61,12 @@ function pixelPath(canvas: SimpleCanvas, nside: number, ipix: number, nstep = 4)
         canvas.ctx.lineTo(x1, y1)
     }
 
-    function clamp(x: number, a: number, b: number) {
+    function clip(x: number, a: number, b: number) {
         return x < a ? a : (x > b ? b : x)
     }
 
     function safe(x: number) {
-        return clamp(x, 1.e-9, 1 - 1.e-9)
+        return clip(x, 1.e-9, 1 - 1.e-9)
     }
 
     for (let i = 0; i < nstep; ++i) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,8 +381,8 @@ function za2pix_nest(nside: number, z: number, a: number) {
 
 function tu2fxy(nside: number, t: number, u: number) {
     const { f, p, q } = tu2fpq(t, u)
-    const x = clamp(Math.floor(nside * p), 0, nside - 1)
-    const y = clamp(Math.floor(nside * q), 0, nside - 1)
+    const x = clip(Math.floor(nside * p), 0, nside - 1)
+    const y = clip(Math.floor(nside * q), 0, nside - 1)
     return { f, x, y }
 }
 
@@ -488,12 +488,12 @@ function tu2fpq(t: number, u: number) {
     t = wrap(t, 8)
     t += -4
     u += 5
-    const pp = clamp((u + t) / 2, 0, 5)
+    const pp = clip((u + t) / 2, 0, 5)
     const PP = Math.floor(pp)
-    const qq = clamp((u - t) / 2, 3 - PP, 6 - PP)
+    const qq = clip((u - t) / 2, 3 - PP, 6 - PP)
     const QQ = Math.floor(qq)
     const V = 5 - (PP + QQ)
-    if (V < 0) { // clamp
+    if (V < 0) { // clip
         return { f: 0, p: 1, q: 1 }
     }
     const H = PP - QQ + 4
@@ -643,7 +643,7 @@ function square(A: number) {
 }
 
 
-function clamp(Z: number, A: number, B: number) {
+function clip(Z: number, A: number, B: number) {
     return Z < A ? A : (Z > B ? B : Z)
 }
 


### PR DESCRIPTION
I suggest to rename the `clamp` utility function to `clip`.

Personally I didn't know the word "clamp", but "clip" I know and there's [numpy.clip](https://docs.scipy.org/doc/numpy/reference/generated/numpy.clip.html).

With Google I see that both "clamp" and "clip" are sometimes used, so it's just a personal preference.

@michitaro - Feel free to just close the PR if you prefer to kee "clamp".