### PR TITLE
Add nside2order and rename uniq ID scheme functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,9 @@ export function order2nside(order: number) {
     return 1 << order
 }
 
+export function nside2order(nside: number) {
+    return Math.log2(nside)
+}
 
 export function nside2npix(nside: number) {
     return 12 * nside * nside
@@ -612,24 +615,32 @@ function fxy2tu(nside: number, f: number, x: number, y: number) {
 }
 
 
-export type HealpixId = number
-
-
-export function encode_id(order: number, index: number): HealpixId {
-    return 4 * ((1 << (2 * order)) - 1) + index
+export function orderpix2uniq(order: number, ipix: number): number {
+    /**
+     * Pack `(order, ipix)` into a `uniq` integer.
+     * 
+     * This HEALPix "unique identifier scheme" is starting to be used widely:
+     * - see section 3.2 in http://healpix.sourceforge.net/pdf/intro.pdf
+     * - see section 2.3.1 in http://ivoa.net/documents/MOC/
+     */
+    return 4 * ((1 << (2 * order)) - 1) + ipix
 }
 
-
-export function decode_id(id: HealpixId) {
-    assert(id <= 0x7fffffff)
+export function uniq2orderpix(uniq: number) {
+    /**
+     * Unpack `uniq` integer into `(order, ipix)`.
+     * 
+     * Inverse of `orderpix2uniq`.
+     */
+    assert(uniq <= 0x7fffffff)
     let order = 0
-    let l = (id >> 2) + 1
+    let l = (uniq >> 2) + 1
     while (l >= 4) {
         l >>= 2
         ++order
     }
-    const index = id - (((1 << (2 * order)) - 1) << 2)
-    return { order, index }
+    const ipix = uniq - (((1 << (2 * order)) - 1) << 2)
+    return { order, ipix }
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export function order2nside(order: number) {
 }
 
 export function nside2order(nside: number) {
-    return Math.log2(nside)
+    return ilog2(nside)
 }
 
 export function nside2npix(nside: number) {
@@ -641,6 +641,20 @@ export function uniq2orderpix(uniq: number) {
     }
     const ipix = uniq - (((1 << (2 * order)) - 1) << 2)
     return { order, ipix }
+}
+
+function ilog2(x: number) {
+    /**
+     * log2 for integer numbers.
+     * 
+     * We're not calling Math.log2 because it's not supported on IE yet.
+     */
+    let o = -1
+    while (x > 0) {
+        x >>= 1;
+        ++o;
+    }
+    return o
 }
 
 


### PR DESCRIPTION
This PR is an attempt to improve the `uniq` related functions:

- Rename `encode_id` to `orderpix2uniq` and add docstring
- Rename `decode_id` to `uniq2orderpix` and add docstring
- Remove type alias `export type HealpixId = number`
- Add `nside2order`, because sometimes people have `nside` and then they need this to these functions that take `order` as an option.

Overall the goal is to have clearer and more consistent function and variable names with the rest of the package. Looking at the old `encode_id` and `decode_id`, I didn't know what they were. Having a new type `HealpixId` that's just `number` and using is only here, but not in all the other places where `ipix` is used doesn't seem useful.

I wonder if the implementation of these methods can be improved.
Is there a reason to keep the bitshifting and wile loop in uniq2orderpix for performance reasons?
Or would calling [math.log2](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2) and maybe also `Math.pow` like in the Python implementation by @tboch in https://github.com/cds-astro/mocpy/blob/master/mocpy/utils.py#L4 be better?
Another alternative could be to add an `ilog2` that's implemented in a similar way as in Python [here](https://github.com/rik0/rk-exempla/blob/master/algorithms/python/ilog2.py)?

@tboch - Thoughts?

Does someone already have a good set of unit test cases that we should add?